### PR TITLE
Enable docker desktop feature flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   portainer:
     image: portainerci/portainer:pr6644
-    command: ["--admin-password", "$$$$2a$$$$10$$$$HX4qSZhtQcvKUNmAsPXuPe9POkM7gdaFPcSnRjokgb8EkMI.1gkSa"]
+    command: ["--admin-password", "$$$$2a$$$$10$$$$HX4qSZhtQcvKUNmAsPXuPe9POkM7gdaFPcSnRjokgb8EkMI.1gkSa", "--feat", "docker-desktop"]
     # command: ["--generate-password"]
     restart: unless-stopped
     security_opt:


### PR DESCRIPTION
Enabling this undocumented feature flag will allow the backend to be
aware of when we are running in a docker extension so we can make
changes such as increasing the JWT expiration times.